### PR TITLE
[MIN-2432] Implement Python Enum schema evolution

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -913,18 +913,21 @@ class JsonFormatTest(JsonFormatBase):
     message = json_format_proto3_pb2.TestMessage()
     text = '{"enumValue": "UNKNOWN_STRING_VALUE"}'
     json_format.Parse(text, message, ignore_unknown_fields=True)
+    # In proto3, there is no difference between the default value and 0.
+    self.assertEqual(message.enum_value, 0)
+
+  def testParseUnknownEnumStringValueProto2(self):
+    message = json_format_pb2.TestNumbers()
+    text = '{"a": "UNKNOWN_STRING_VALUE"}'
+    json_format.Parse(text, message, ignore_unknown_fields=True)
+    # In proto2 we can see that the field was not set at all.
+    self.assertFalse(message.HasField("a"))
 
   def testParseUnknownEnumStringValueRepeatedProto3(self):
     message = json_format_proto3_pb2.TestMessage()
     text = '{"repeatedEnumValue": ["UNKNOWN_STRING_VALUE", "FOO", "BAR"]}'
     json_format.Parse(text, message, ignore_unknown_fields=True)
     self.assertEquals(len(message.repeated_enum_value), 2)
-
-  def testParseUnknownEnumStringValueProto2(self):
-    message = json_format_pb2.TestNumbers()
-    text = '{"a": "UNKNOWN_STRING_VALUE"}'
-    json_format.Parse(text, message, ignore_unknown_fields=True)
-    self.assertFalse(message.HasField("a"))
 
   def testBytes(self):
     message = json_format_proto3_pb2.TestMessage()

--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -909,6 +909,23 @@ class JsonFormatTest(JsonFormatBase):
         'for enum type protobuf_unittest.TestAllTypes.NestedEnum.',
         json_format.Parse, '{"optionalNestedEnum": 12345}', message)
 
+  def testParseUnknownEnumStringValueProto3(self):
+    message = json_format_proto3_pb2.TestMessage()
+    text = '{"enumValue": "UNKNOWN_STRING_VALUE"}'
+    json_format.Parse(text, message, ignore_unknown_fields=True)
+
+  def testParseUnknownEnumStringValueRepeatedProto3(self):
+    message = json_format_proto3_pb2.TestMessage()
+    text = '{"repeatedEnumValue": ["UNKNOWN_STRING_VALUE", "FOO", "BAR"]}'
+    json_format.Parse(text, message, ignore_unknown_fields=True)
+    self.assertEquals(len(message.repeated_enum_value), 2)
+
+  def testParseUnknownEnumStringValueProto2(self):
+    message = json_format_pb2.TestNumbers()
+    text = '{"a": "UNKNOWN_STRING_VALUE"}'
+    json_format.Parse(text, message, ignore_unknown_fields=True)
+    self.assertFalse(message.HasField("a"))
+
   def testBytes(self):
     message = json_format_proto3_pb2.TestMessage()
     # Test url base64

--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -909,6 +909,24 @@ class JsonFormatTest(JsonFormatBase):
         'for enum type protobuf_unittest.TestAllTypes.NestedEnum.',
         json_format.Parse, '{"optionalNestedEnum": 12345}', message)
 
+  def testParseUnknownEnumStringValueProto2(self):
+    message = json_format_pb2.TestNumbers()
+    # Note that in src/google/protobuf/util/json_format.proto::TestNumbers
+    # has a field 'optional MyType a = 1', which is different
+    # from the test below that are using
+    # src/google/protobuf/util/json_format_proto3.proto::TestMessage.
+    text = '{"a": "UNKNOWN_STRING_VALUE"}'
+    json_format.Parse(text, message, ignore_unknown_fields=True)
+    # In proto2 we can see that the field was not set at all.
+    self.assertFalse(message.HasField("a"))
+
+  def testParseErrorCorrectCatchForUnknownEnumValue(self):
+    message = json_format_pb2.TestNumbers()
+    self.assertRaisesRegexp(
+        json_format.ParseError,
+        'Invalid enum value',
+        json_format.Parse, '{"a": "UNKNOWN_STRING_VALUE"}', message)
+
   def testParseUnknownEnumStringValueProto3(self):
     message = json_format_proto3_pb2.TestMessage()
     text = '{"enumValue": "UNKNOWN_STRING_VALUE"}'
@@ -916,13 +934,10 @@ class JsonFormatTest(JsonFormatBase):
     # In proto3, there is no difference between the default value and 0.
     self.assertEqual(message.enum_value, 0)
 
-  def testParseUnknownEnumStringValueProto2(self):
-    message = json_format_pb2.TestNumbers()
-    text = '{"a": "UNKNOWN_STRING_VALUE"}'
-    json_format.Parse(text, message, ignore_unknown_fields=True)
-    # In proto2 we can see that the field was not set at all.
-    self.assertFalse(message.HasField("a"))
-
+  # Note that in noom-contracts we banned the repeated enum fields, so this test
+  # is not adding value for Noom's use of this library.
+  # Still, we are testing that the behavior here is consistent with what
+  # binary serialization would do.
   def testParseUnknownEnumStringValueRepeatedProto3(self):
     message = json_format_proto3_pb2.TestMessage()
     text = '{"repeatedEnumValue": ["UNKNOWN_STRING_VALUE", "FOO", "BAR"]}'

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -130,6 +130,12 @@ class _MaybeSuppressUnknownEnumStringValueParseError():
     ...
 
   If should_suppress is True, the _UnknownEnumStringValueParseError will be ignored in the context body.
+
+  The motivation for the context manager is to avoid a bigger refactor that would enable _ConvertScalarFieldValue to
+  signal to the caller that the field should be ignored.
+
+  We want to avoid a bigger refactor because we are maintaining a fork and we want changes to be minimal to simplify
+  merging with upstream.
   """
   def __init__(self, should_suppress):
     self.should_suppress = should_suppress

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -118,7 +118,10 @@ class ParseError(Error):
 
 
 class _UnknownEnumStringValueParseError(ParseError):
-  """Thrown if an unknown enum string value is encountered."""
+  """
+  Thrown if an unknown enum string value is encountered.
+  We inherit ParseError to avoid breaking the code that might expect ParseError.
+  """
 
 
 @contextmanager

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -117,7 +117,7 @@ class ParseError(Error):
 
 
 class _UnknownEnumStringValueParseError(ParseError):
-  """Thrown if an unknown enum string value is encountered. This exception never leaks outside of the module."""
+  """Thrown if an unknown enum string value is encountered."""
 
 
 class _MaybeSuppressUnknownEnumStringValueParseError():

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -123,6 +123,12 @@ class _UnknownEnumStringValueParseError(ParseError):
 
 @contextmanager
 def _MaybeSuppressUnknownEnumStringValueParseError(should_suppress: bool):
+    """
+    This context manager will suppress _UnknownEnumStringValueParseError if the should_suppress is set to true. Usage:
+
+    with _MaybeSuppressUnknownEnumStringValueParseError(True):
+        run_some_code_that_might_throw()
+    """
     try:
         yield
     except _UnknownEnumStringValueParseError as ex:


### PR DESCRIPTION
# Motivation

Tech doc:
https://docs.google.com/document/d/1p5LUSTWrVBcT9F2wXBgHBDT3OJyOm5BpXAyTpwwDVts/edit#

# Changes

In this PR we actually fix the Python protobuf library not to break when unknown enum value is encountered if ignoreUnknownFields is true.

The design principles for the change were:
* make the change as small as possible, so it's easy to keep up to date with the upstream
* if one element is unknown in an array of elements, other elements should still parse (see unit tests)

Changes:
* Change `_ConvertScalarFieldValue` so it throws a special exception when unknown enum string value is encountered.
* Wrap every invocation of `_ConvertScalarFieldValue` to optionally ignore the new exception thrown.
* Add unit tests

To write this PR, I reached out for input on #python-club [on slack](https://noom.slack.com/archives/C020854DJDU/p1655740069429799)

# Tested

Executed the test plan from here: https://github.com/noom/protobuf/pull/1 to test this within the `protobuf` repo.

Also tested as part of `noom-contracts` repo: https://github.com/noom/noom-contracts/pull/293