### PR TITLE
Testing JSON including_default_value_fields behavior

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -1281,5 +1281,17 @@ class JsonFormatTest(JsonFormatBase):
     json_format.Parse('{"payload": {}, "child": {"child":{}}}',
                       message, max_recursion_depth=3)
 
+  def testIncludingDefaultValues(self):
+    message = json_format_proto3_pb2.TestMessage()
+    js_dict = json_format.MessageToDict(message, including_default_value_fields=True)
+    self.assertFalse("messageValue" in js_dict)
+    self.assertTrue("int32Value" in js_dict)
+
+  def testIncludingDefaultValuesWrapper(self):
+    message = json_format_proto3_pb2.TestWrapper()
+    js_dict = json_format.MessageToDict(message, including_default_value_fields=True)
+    self.assertFalse("stringValue" in js_dict)
+    self.assertTrue("repeatedStringValue" in js_dict)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
# Motivation

I don't intend to merge this.

Test behavior of `includingDefaultValueFields` when we have an unset nested message field.

# Observations

* In C++ "include default fields" is actually called [always_print_primitive_fields](https://github.com/protocolbuffers/protobuf/blob/19d74e7369a85f01935947af65352b72616fc2ac/src/google/protobuf/json/json.h#L72) which specifies that this affects only primitive fields.

* In Java, there is a [unit test](https://github.com/protocolbuffers/protobuf/blob/1ac05394a59f5132f0b14a589851a76d627e32f3/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java#L1510) that shows that even if `includingDefaultValueFields` we will not emit a `null` for unset nested message

* In Python, we see in this PR that `including_default_value_fields` doesn't affect nested messages. Tested with `bazel test //python:json_format_test`

